### PR TITLE
Precompute indices

### DIFF
--- a/src/stackedtime/solverdata.jl
+++ b/src/stackedtime/solverdata.jl
@@ -68,7 +68,7 @@ function var_CiSc end
 
 """
     assign_fc!(x::Vector, exog::Vector, vind::Int, sd::StackedTimeSolverData, fc::FinalCondition)
-    
+
 Applying the final condition `fc` for variable with index `vind`. Exogenous data
 is provided in `exog` and stacked time solver data in `sd`. This function
 updates the solution vector `x` in place and returns `x`.
@@ -84,7 +84,7 @@ function assign_fc! end
 #######
 
 @inline function var_CiSc(::StackedTimeSolverData, ::ModelVariable, ::FCNone)
-    # No Jacobian correction 
+    # No Jacobian correction
     return Dict{Int,Vector{Float64}}()
 end
 
@@ -96,7 +96,7 @@ end
 #######
 
 @inline function var_CiSc(::StackedTimeSolverData, ::ModelVariable, ::FCGiven)
-    # No Jacobian correction 
+    # No Jacobian correction
     return Dict{Int,Vector{Float64}}()
 end
 
@@ -111,7 +111,7 @@ end
 #######
 
 @inline function var_CiSc(::StackedTimeSolverData, ::ModelVariable, ::FCMatchSSLevel)
-    # No Jacobian correction 
+    # No Jacobian correction
     return Dict{Int,Vector{Float64}}()
 end
 
@@ -366,7 +366,13 @@ function StackedTimeSolverData(model::Model, plan::Plan, fctype::AbstractVector{
     # Prep the Jacobian matrix
     neq = 0 # running counter of equations added to matrix
     # Model equations are the same for each sim period, just shifted according to t
-    Jblock = [ti + NT * (ModelBaseEcon._index_of_var(var, unknowns) - 1) for eqn in equations for (var, ti) in keys(eqn.tsrefs)]
+
+    # Precompute index lookup for variables
+    var_to_idx = Dict{ModelVariable, Int}()
+    for (idx, var) in enumerate(unknowns)
+        var_to_idx[var] = idx
+    end
+    Jblock = [ti + NT * (var_to_idx[var] - 1) for eqn in equations for (var, ti) in keys(eqn.tsrefs)]
     Iblock = [i for (i, eqn) in enumerate(equations) for _ in eqn.tsrefs]
     Tblock = -model.maxlag:model.maxlead
     for t in sim
@@ -392,7 +398,7 @@ function StackedTimeSolverData(model::Model, plan::Plan, fctype::AbstractVector{
     # We also need the times of the final conditions
     push!(TT, term)
 
-    # 
+    #
     exog_mask = falses(nunknowns * NT)
     # Initial conditions are set as exogenous values
     exog_mask[vec(LI[init, :])] .= true
@@ -418,7 +424,7 @@ end
 """
     assign_exog_data!(x::Matrix, exog::Matrix, sd::StackedTimeSolverData)
 
-Assign the exogenous points into `x` according to the plan with which `sd` was created using 
+Assign the exogenous points into `x` according to the plan with which `sd` was created using
 exogenous data from `exog`.  Also call [`assign_final_condition!`](@ref).
 
 !!! warning
@@ -434,7 +440,7 @@ end
 """
     assign_final_condition!(x::Matrix, exog::Matrix, sd::StackedTimeSolver)
 
-Assign the final conditions into `x`. The final condition types for the different variables of the model 
+Assign the final conditions into `x`. The final condition types for the different variables of the model
 are stored in the the solver data `sd`. `exog` is used for [`fcgiven`](@ref).
 
 !!! warning
@@ -464,7 +470,7 @@ function stackedtime_R!(res::AbstractArray{Float64,1}, point::AbstractArray{Floa
     return res
 end
 
-#= disable 
+#= disable
 
 # this is not necessary with log-transformed variables
 # we keep it because it might be necessary for other transformations in the future.
@@ -571,7 +577,7 @@ function update_CiSc!(x, sd, ::Val{fcnatural})
         end
     end
     return nothing
-end 
+end
 =#
 
 

--- a/src/stackedtime/solverdata.jl
+++ b/src/stackedtime/solverdata.jl
@@ -242,7 +242,8 @@ function update_plan!(sd::StackedTimeSolverData, model::Model, plan::Plan; chang
         II, JJ, VV = Int[], Int[], Float64[]
         last_sim_t = last(sim)
         for (vi, (v, fc)) in enumerate(zip(unknowns, sd.FC))
-            @assert vi == ModelBaseEcon._index_of_var(v, unknowns)
+            # This assert is expensive, consider reenable in some debug mode option
+            # @assert vi == ModelBaseEcon._index_of_var(v, unknowns)
             # var_CiSc returns a Dict with keys equal to the column offset relative to last_sim_t
             # and values containing the column values.
             for (offset, values) in var_CiSc(sd, v, fc)


### PR DESCRIPTION
First commit:
Precompute looking up indices for all variables in `StackedTimeSolver Data`

This has an identical analysis as https://github.com/bankofcanada/ModelBaseEcon.jl/pull/41.
It is possible some aux function like this should be put into ModelBaseEcon

This takes solving the FRB-US model from 149ms to 83ms.

---------
Second commit:
disable an expensive assert

This has the same issue as the one worked around in https://github.com/bankofcanada/ModelBaseEcon.jl/pull/41.

It takes solving the FRB-US model from 83ms to 54ms

-----

The benchmarks have been made on top of https://github.com/bankofcanada/ModelBaseEcon.jl/pull/41