### PR TITLE
Remove trailing whitespace

### DIFF
--- a/src/Plans.jl
+++ b/src/Plans.jl
@@ -89,7 +89,7 @@ function Plan(model::Model, range::AbstractUnitRange)
 end
 
 #######################################
-# AbstractVector interface 
+# AbstractVector interface
 
 Base.size(p::Plan) = size(p.range)
 Base.axes(p::Plan) = (p.range,)
@@ -221,7 +221,7 @@ function Base.show(io::IO, p::Plan)
 end
 
 #######################################
-# export and import Plan instances 
+# export and import Plan instances
 
 export exportplan, importplan
 

--- a/src/StateSpaceEcon.jl
+++ b/src/StateSpaceEcon.jl
@@ -30,7 +30,7 @@ const _solvers = LittleDict{Symbol, Module}(
     :firstorder => FirstOrderSolver
 )
 
-function getsolvermodule(solvername::Symbol) 
+function getsolvermodule(solvername::Symbol)
     SolverModule = get(_solvers, solvername, nothing)
     if SolverModule === nothing
         error(ArgumentError("Unknown solver :$solvername."))

--- a/src/firstorder/QZ.jl
+++ b/src/firstorder/QZ.jl
@@ -32,7 +32,7 @@ struct QZData
 end
 
 # reuse the space allocated in bwork for iwork -- in Fortran INTEGER and LOGICAL are both 32-bit.
-# CAREFUL not to use both in the same call to lapack. 
+# CAREFUL not to use both in the same call to lapack.
 # bwork is used in call to dgges, iwork is used in call to dtgsen
 Base.getproperty(qz::QZData, name::Symbol) = getfield(qz, name === :iwork ? :bwork :
                                                           name === :liwork ? :lbwork :
@@ -65,8 +65,8 @@ function _dgges!(qz::QZData, selctg=C_NULL)
     end
     ccall((LAPACK.@blasfunc(dgges_), LAPACK.libblastrampoline), Cvoid, (
             Ref{UInt8}, Ref{UInt8}, Ref{UInt8}, Ptr{Cvoid},   # JOBVSL, JOBVSR, SORT, SELCTG
-            Ref{BlasInt}, Ptr{Float64}, Ref{BlasInt}, # N, in A out S, LDA, 
-            Ptr{Float64}, Ref{BlasInt}, # in B out T, LDB, 
+            Ref{BlasInt}, Ptr{Float64}, Ref{BlasInt}, # N, in A out S, LDA,
+            Ptr{Float64}, Ref{BlasInt}, # in B out T, LDB,
             Ptr{BlasInt}, # out SDIM
             Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, # ALPHAR, ALPHAI, BETA
             Ptr{Float64}, Ref{BlasInt}, # VSL, LDVSL
@@ -87,7 +87,7 @@ function _dgges!(qz::QZData, selctg=C_NULL)
 end
 
 function call_dgges!(qz)
-    # first call to ask how much work space it needs 
+    # first call to ask how much work space it needs
     qz.lwork[] = -1
     info = _dgges!(qz)
     if info != 0
@@ -110,8 +110,8 @@ function _dtgsen!(qz::QZData, select::Vector{BlasInt})
     ccall((LAPACK.@blasfunc(dtgsen_), LAPACK.libblastrampoline), Cvoid, (
             Ref{BlasInt}, Ref{BlasInt}, Ref{BlasInt}, # IJOB, WANTQ, WANTZ,
             Ptr{BlasInt}, # SELECT
-            Ref{BlasInt}, Ptr{Float64}, Ref{BlasInt}, # N, in/out A (a.k.a. S), LDA, 
-            Ptr{Float64}, Ref{BlasInt}, # in/out B (a.k.a. T), LDB, 
+            Ref{BlasInt}, Ptr{Float64}, Ref{BlasInt}, # N, in/out A (a.k.a. S), LDA,
+            Ptr{Float64}, Ref{BlasInt}, # in/out B (a.k.a. T), LDB,
             Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, # ALPHAR, ALPHAI, BETA
             Ptr{Float64}, Ref{BlasInt}, # VSL, LDVSL
             Ptr{Float64}, Ref{BlasInt}, # VSR, LDVSR
@@ -138,7 +138,7 @@ function _dtgsen!(qz::QZData, select::Vector{BlasInt})
 end
 
 function call_dtgsen!(qz, select)
-    # first call to figure out how much work space is needed 
+    # first call to figure out how much work space is needed
     qz.lwork[] = -1
     resize!(qz.work, max(length(qz.work), 1))
     qz.liwork[] = -1
@@ -147,7 +147,7 @@ function call_dtgsen!(qz, select)
     if info != 0
         error("Call to dtgsen failed with INFO = $(qz.info[]).")
     end
-    # resize work arrays, if necessary, and call again, this time for real 
+    # resize work arrays, if necessary, and call again, this time for real
     resize!(qz.work, max(length(qz.work), Int(qz.work[1])))
     qz.lwork[] = length(qz.work)
     resize!(qz.iwork, max(length(qz.iwork), Int(qz.iwork[1])))
@@ -176,7 +176,7 @@ _diffg(qz) = @.(qz.α_re^2 + qz.α_im^2 - qz.β^2)
     run_qz(A, B [, nstable])
 
 Compute the QZ factorization (a.k.a. Generalized Schur decomposition) of the
-matrix pencil (A,B). Return an instance of `QZData`, which contains the `Q,S,T,Z` 
+matrix pencil (A,B). Return an instance of `QZData`, which contains the `Q,S,T,Z`
 matrices of the factorization.
 
 The optional argument `nstable` is an integer that controls whether or not to
@@ -198,7 +198,7 @@ function _run_qz!(qz::QZData, want_stable::Int)
     # we need sorting
     #           _dgges!(qz, @_select_stable)
     # doesn't work due to round-off errors: there may be unit eigenvalues that are ±eps()
-    # 
+    #
     # instead, find a "cutoff value" in the vector of eigenvalues, such that we have
     # `want_stable` of them strictly above the cutoff and the rest below or at the cutoff.
     N = qz.N

--- a/src/firstorder/shockdecomp.jl
+++ b/src/firstorder/shockdecomp.jl
@@ -71,7 +71,7 @@ function shockdecomp(model::Model, plan::Plan, exog_data::SimData;
     SD_RHS = zeros(S.nbck + S.nfwd, nrhs)
     SD_EX = zeros(S.nex, S.nex)
 
-    # tnow is the Int index corresponding to the current period 
+    # tnow is the Int index corresponding to the current period
     tnow = model.maxlag
     # prepare initial conditions (only bck_t are used)
     for ind in S.ibck
@@ -117,7 +117,7 @@ function shockdecomp(model::Model, plan::Plan, exog_data::SimData;
         #    otherwise, the contribution is already in RHS, so magic_coef is set to 1.0 to take it into account.
 
 
-        # solve 
+        # solve
         # for shocked
         ldiv!(view(S.sol_t, S.ien), sd.MAT_n, S.RHS)
         # for contributions

--- a/src/firstorder/simulate.jl
+++ b/src/firstorder/simulate.jl
@@ -98,7 +98,7 @@ function simulate(model::Model, plan::Plan, exog::AbstractMatrix;
             deviation, anticipate, verbose, baseline, kwargs...)
     end
 
-    # transform exogenous data 
+    # transform exogenous data
     logvars = [islog(var) | isneglog(var) for var in model.varshks]
     need_trans = any(logvars)
     need_baseline = !deviation || (deviation && need_trans)
@@ -133,7 +133,7 @@ function simulate(model::Model, plan::Plan, exog::AbstractMatrix;
     # Let’s start at the very beginning, a very good place to start.
     ##################
 
-    # tnow is the row-index in exog corresponding to the current period 
+    # tnow is the row-index in exog corresponding to the current period
     tnow = model.maxlag
 
     # prepare initial conditions (only bck_t are used)
@@ -175,7 +175,7 @@ function simulate(model::Model, plan::Plan, exog::AbstractMatrix;
                 dispatch)
         end =#
 
-        # TODO: This mapping can be precomputed!  
+        # TODO: This mapping can be precomputed!
         # Populate the sim
         for (simind, var) in enumerate(model.varshks)
             vname = var.name
@@ -255,7 +255,7 @@ function fo_sim_step!(
         for (inds, def_xflag, offset) in ((vm.bck_inds, false, 0),
             (vm.fwd_inds, false, 0),
             (vm.ex_inds, true, S.oex))
-            # def_xflag : default xflag in empty plan, i.e. `false` for variables, `true` for shocks 
+            # def_xflag : default xflag in empty plan, i.e. `false` for variables, `true` for shocks
             # Note: bck_inds listed first for a good reason
             # it's possible for (var,0) to be both in bck and fwd (mixed variable)
             # if exogenous, we set only one of them, not both

--- a/src/firstorder/solve.jl
+++ b/src/firstorder/solve.jl
@@ -15,8 +15,8 @@ end
 struct VarMaps
     # map of model variables to their indexes in the model
     vi::LittleDict{Symbol,Int}
-    nfwd::Int  # number of variables classified as forward looking 
-    nbck::Int  # number of variables classified as backward looking 
+    nfwd::Int  # number of variables classified as forward looking
+    nbck::Int  # number of variables classified as backward looking
     nex::Int   # number of variables classified as exogenous (includes shocks + @exog)
     oex::Int   # offset of exogenous class in the global indexing
     # maps of first-order variables by class : ind => (var.name, lag)
@@ -35,14 +35,14 @@ end
 
 function VarMaps(model::Model)
     #
-    # Precompute the index of each model variable 
+    # Precompute the index of each model variable
     # Not related to first-order solver, just so we don't have to call indexin() all the time
     #
     vi = LittleDict{Symbol,Int}(
         var.name => ind for (ind, var) in enumerate(model.allvars)
     )
     #
-    # define variables for lags and leads more than 1 
+    # define variables for lags and leads more than 1
     # also categorize variables as fwd, bck, and ex
     #
     fwd_vars = Tuple{Symbol,Int}[]
@@ -159,7 +159,7 @@ function fill_fosystem!(sys::FirstOrderSystem, JAC::SparseMatrixCSC, model::Mode
             fwd_i = get(vm.fwd_inds, (var, tt - 1), nothing)
             FWD[eqind, fwd_i] = val
         else # tt == 0
-            # could be either or both; 
+            # could be either or both;
             bck_i = get(vm.bck_inds, (var, 0), nothing)
             if bck_i !== nothing
                 # prefer to treat it as bck_var, if both
@@ -209,7 +209,7 @@ struct FirstOrderSD
     vm::VarMaps
     sys::FirstOrderSystem
     qz::QZData
-    # various matrices 
+    # various matrices
     RbyZbb::Matrix{Float64}
     MAT::Matrix{Float64}
     # precomputed for empty plan
@@ -276,11 +276,11 @@ function first_order_system(qz::QZData, EX::Matrix{Float64}, nbck::Int, nfwd::In
 
     ### fill the backward-looking rows
     MAT[1:nbck, 1:nbck] = Sbb / Zbb
-    # MAT[1:nbck, nbck .+(1:nfwd)] .= 0  # already zero 
+    # MAT[1:nbck, nbck .+(1:nfwd)] .= 0  # already zero
     MAT[1:nbck, oex.+(1:nex)] = QEX[1:nbck, :] - (Tbf - Tbb * (Zbb \ Zbf)) * TiXf
 
     ### fill the forward-looking rows
-    # MAT[nbck .+ (1:nfwd), 1:nbck] .= 0  # already zero 
+    # MAT[nbck .+ (1:nfwd), 1:nbck] .= 0  # already zero
     MAT[nbck.+(1:nfwd), nbck.+(1:nfwd)] = Zff'
     MAT[nbck.+(1:nfwd), oex.+(1:nex)] = TiXf
 

--- a/src/plandata.jl
+++ b/src/plandata.jl
@@ -26,7 +26,7 @@ returns [`SimData`](@ref). See also [`zeroworkspace`](@ref)
 
 """
 function zeroarray end
-    
+
 """
     steadystatearray(model, plan; [ref=firstdate(plan) + m.maxlag])
 

--- a/src/simdata.jl
+++ b/src/simdata.jl
@@ -84,7 +84,7 @@ data2array(simdata::SimData, vars, range; copy=false) = copy ? Base.copy(rawdata
     data2workspace(data; copy=false)
     data2workspace(data, model, plan; copy=false)
     data2workspace(data, vars, range; copy=false)
-    
+
 Convert a [`SimData`](@ref) to a [`Workspace`](@ref TimeSeriesEcon.Workspace).
 """
 function data2workspace end

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -46,11 +46,11 @@ dynamic model for the given plan range and final condition. We verify the
 residual and issue a warning, but do not enforce this. See
 [`steadystatedata`](@ref).
 
-As part of the algorithm we run a simulation with the given plan, data and solver. 
+As part of the algorithm we run a simulation with the given plan, data and solver.
 See [`simulate`](@ref) for additional options that control the simulation.
 
 Note that unlike [`simulate`](@ref), here we require `exogdata` and `control` to
-be `MVTSeries`, i.e. plain `Array` or `Workspace` are not allowed. 
+be `MVTSeries`, i.e. plain `Array` or `Workspace` are not allowed.
 
 The returned value is a `Workspace` with three things in it: `c` contains a copy
 of `control`, `s` contains the simulated solution for the given `plan` and

--- a/src/stackedtime/fctypes.jl
+++ b/src/stackedtime/fctypes.jl
@@ -124,7 +124,7 @@ end
     setfc!(fc_vector, model, variable, new_fc)
 
 Update the final condition for the given `variable` in the given `fc_vector` to
-`new_fc`. The `fc_vector` is the output of [`setfc`](@ref).    
+`new_fc`. The `fc_vector` is the output of [`setfc`](@ref).
 """
 function setfc! end
 function setfc!(fc_vec::AbstractVector{FinalCondition}, m::Model, v::Union{ModelVariable,Symbol}, new_fc::FinalCondition)

--- a/src/stackedtime/shockdecomp.jl
+++ b/src/stackedtime/shockdecomp.jl
@@ -19,7 +19,7 @@ dynamic model for the given plan range and final condition. We verify the
 residual and issue a warning, but do not enforce this. See
 [`steadystatedata`](@ref).
 
-As part of the algorithm we run a simulation with the given `plan`, 
+As part of the algorithm we run a simulation with the given `plan`,
 `exog_data` and `fctype`.  See [`simulate`](@ref) for other options.
 
 !!! note
@@ -129,7 +129,7 @@ function shockdecomp(m::Model, p::Plan, exog_data::SimData;
 
     # now do the decomposition
     begin
-        # we build a sparse matrix 
+        # we build a sparse matrix
         SDI = Int[]     # row indexes
         SDJ = Int[]     # column indexes
         SDV = Float64[] # values
@@ -212,7 +212,7 @@ function shockdecomp(m::Model, p::Plan, exog_data::SimData;
                 continue
             end
             v_inv_endo_inds = inv_endo_inds[v_inds[v_endo_mask]]
-            v_data = result.sd[v] 
+            v_data = result.sd[v]
             # assign contributions to endogenous points
             v_data[v_endo_mask, :] = SDMAT[v_inv_endo_inds, :]
             # contributions of initial conditions already assigned

--- a/src/stackedtime/simulate.jl
+++ b/src/stackedtime/simulate.jl
@@ -22,8 +22,8 @@ Solve the simulation problem.
   * `verbose` - whether or not to print progress information.
   * `sparse_solver` (optional) - a function called to solve the linear system A
     x = b for x. Defaults to A\\b
-  * `linesearch::Bool` - When `true` the Newton-Raphson is modified to include a 
-    search along the descent direction for a sufficient decrease in f. It will 
+  * `linesearch::Bool` - When `true` the Newton-Raphson is modified to include a
+    search along the descent direction for a sufficient decrease in f. It will
     do this at each iteration. Default is `false`.
 
 """
@@ -260,8 +260,8 @@ function simulate(m::Model,
             end
         else
             # when expectation_horizon is not given,
-            # the first and last simulations use the true 
-            # simulation range and final condition, while the intermediate 
+            # the first and last simulations use the true
+            # simulation range and final condition, while the intermediate
             # simulations use expectation_horizon steps with fcnatural
             if expectation_horizon == 0
                 expectation_horizon = length(sim)
@@ -273,7 +273,7 @@ function simulate(m::Model,
             nterm = length(term)
             # first simulation
             let t = t0
-                # first run is with the full range, the true fctype, 
+                # first run is with the full range, the true fctype,
                 # and only the first period is imposed
                 exog_inds = p_unant[t, Val(:inds)]
                 psim = Plan(m, t:T)
@@ -299,8 +299,8 @@ function simulate(m::Model,
             for t in sim[2:end]
                 exog_inds = p_unant[t, Val(:inds)]
                 # we need to run a simulation if a variable is exogenous, or if a shock value is not zero
-                # these intermediate simulations are always with fcnatural, 
-                #       have length equal to expectation_horizon and 
+                # these intermediate simulations are always with fcnatural,
+                #       have length equal to expectation_horizon and
                 #       only the first period is imposed
                 if (maximum(abs, x[t, exog_inds] .- exog_unant[t, exog_inds]) < tol) #= && (exog_inds == shkinds) =#
                     continue
@@ -322,7 +322,7 @@ function simulate(m::Model,
 
                 setexog!(psim1, t0, exog_inds)
                 update_plan!(sdata, m, psim1)
-                # note that the range always goes from 0 to expectation_horizon-1, 
+                # note that the range always goes from 0 to expectation_horizon-1,
                 # so we need to add t in order to get the correct set of rows of x
                 sim_range = t .+ UnitRange{Int}(psim.range)
                 xx = view(x, sim_range, :)

--- a/src/stackedtime/solverdata.jl
+++ b/src/stackedtime/solverdata.jl
@@ -68,7 +68,7 @@ function var_CiSc end
 
 """
     assign_fc!(x::Vector, exog::Vector, vind::Int, sd::StackedTimeSolverData, fc::FinalCondition)
-    
+
 Applying the final condition `fc` for variable with index `vind`. Exogenous data
 is provided in `exog` and stacked time solver data in `sd`. This function
 updates the solution vector `x` in place and returns `x`.
@@ -84,7 +84,7 @@ function assign_fc! end
 #######
 
 @inline function var_CiSc(::StackedTimeSolverData, ::ModelVariable, ::FCNone)
-    # No Jacobian correction 
+    # No Jacobian correction
     return Dict{Int,Vector{Float64}}()
 end
 
@@ -96,7 +96,7 @@ end
 #######
 
 @inline function var_CiSc(::StackedTimeSolverData, ::ModelVariable, ::FCGiven)
-    # No Jacobian correction 
+    # No Jacobian correction
     return Dict{Int,Vector{Float64}}()
 end
 
@@ -111,7 +111,7 @@ end
 #######
 
 @inline function var_CiSc(::StackedTimeSolverData, ::ModelVariable, ::FCMatchSSLevel)
-    # No Jacobian correction 
+    # No Jacobian correction
     return Dict{Int,Vector{Float64}}()
 end
 
@@ -392,7 +392,7 @@ function StackedTimeSolverData(model::Model, plan::Plan, fctype::AbstractVector{
     # We also need the times of the final conditions
     push!(TT, term)
 
-    # 
+    #
     exog_mask = falses(nunknowns * NT)
     # Initial conditions are set as exogenous values
     exog_mask[vec(LI[init, :])] .= true
@@ -418,7 +418,7 @@ end
 """
     assign_exog_data!(x::Matrix, exog::Matrix, sd::StackedTimeSolverData)
 
-Assign the exogenous points into `x` according to the plan with which `sd` was created using 
+Assign the exogenous points into `x` according to the plan with which `sd` was created using
 exogenous data from `exog`.  Also call [`assign_final_condition!`](@ref).
 
 !!! warning
@@ -434,7 +434,7 @@ end
 """
     assign_final_condition!(x::Matrix, exog::Matrix, sd::StackedTimeSolver)
 
-Assign the final conditions into `x`. The final condition types for the different variables of the model 
+Assign the final conditions into `x`. The final condition types for the different variables of the model
 are stored in the the solver data `sd`. `exog` is used for [`fcgiven`](@ref).
 
 !!! warning
@@ -464,7 +464,7 @@ function stackedtime_R!(res::AbstractArray{Float64,1}, point::AbstractArray{Floa
     return res
 end
 
-#= disable 
+#= disable
 
 # this is not necessary with log-transformed variables
 # we keep it because it might be necessary for other transformations in the future.
@@ -571,7 +571,7 @@ function update_CiSc!(x, sd, ::Val{fcnatural})
         end
     end
     return nothing
-end 
+end
 =#
 
 

--- a/src/steadystate/1dsolvers.jl
+++ b/src/steadystate/1dsolvers.jl
@@ -6,14 +6,14 @@
 ##################################################################################
 
 """
-    1dsolvers.jl 
+    1dsolvers.jl
 
 This file contains solvers used in SteadyStateSolver. The functions here solve a
 problem where a multivariate function is solved in a single coordinate, keeping
 the other coordinates fixed. We have 1d- Newton and a variant of the bisection
 method.
 
-### Important note: 
+### Important note:
 These functions are used in pre-solving the steady state. They have a peculiar
 feature that they fail if the first derivative is zero. Normally, if the
 residual is zero, that would be a solution regardless of the first derivative.
@@ -148,10 +148,10 @@ function bisect!(F::Function, vals::AbstractVector{T}, ind::Int64, deriv::T; max
     end
 
     #######################################################################
-    # The problem is to find two points that bracket the solution, i.e. such 
-    # that f(x0) and f(x1) have opposite signs. 
+    # The problem is to find two points that bracket the solution, i.e. such
+    # that f(x0) and f(x1) have opposite signs.
 
-    # With the sign of f0 and the known derivative at x0 we can search for x1 
+    # With the sign of f0 and the known derivative at x0 we can search for x1
     # in the direction in which the function approaches zero.)
     # if the derivative is zero at the initial point, that's an argument error
     abs(deriv) < 1e-10 && return false
@@ -160,7 +160,7 @@ function bisect!(F::Function, vals::AbstractVector{T}, ind::Int64, deriv::T; max
     # First point - that's easy
     x0 = vals[ind]
     f0 = f(x0)
-    # is x0 the solution? 
+    # is x0 the solution?
     abs(f0) < tol && return true
     isnan(f0) && return false
 
@@ -177,17 +177,17 @@ function bisect!(F::Function, vals::AbstractVector{T}, ind::Int64, deriv::T; max
     end
     # is x1 the solution?
     abs(f1) < tol && return true
-    # does (x0, x1) bracket the solution? 
+    # does (x0, x1) bracket the solution?
     f1 * f0 < 0.0 && return _do_bisect(x0, f0, x1, f1)
 
-    # We have two points (x0, f0) and (x1, f1), but f0 and f1 are of the same sign. 
-    # It may be that there's a root between them, but we overshot, or that 
+    # We have two points (x0, f0) and (x1, f1), but f0 and f1 are of the same sign.
+    # It may be that there's a root between them, but we overshot, or that
     # the root is beyond x1 (from x0)
 
     # try the midpoint
     x2 = 0.5 * (x0 + x1)
     f2 = f(x2)
-    # if x2 the solution? 
+    # if x2 the solution?
     abs(f2) < tol && return true
     # does (x0, x2) bracket the solution?
     if f0 * f2 < 0.0
@@ -195,15 +195,15 @@ function bisect!(F::Function, vals::AbstractVector{T}, ind::Int64, deriv::T; max
         return abs(f0) < abs(f1) ? _do_bisect(x0, f0, x2, f2) : _do_bisect(x1, f1, x2, f2)
     end
 
-    # We have three points with the same sign of f. 
+    # We have three points with the same sign of f.
     # Desperately try a few iterations of inverse quadratic interpolation.
     for i = 1:20
         # Approximate f-inverse with a quadratic through the three points we have and set x3 = f_inverse(0)
         x3 = f0 * f1 * x2 / (f2 - f0) / (f2 - f1) + f0 * x1 * f2 / (f1 - f0) / (f1 - f2) + x0 * f1 * f2 / (f0 - f1) / (f0 - f2)
         f3 = f(x3)
-        # is it a bad point? 
+        # is it a bad point?
         (isnan(f3) || isinf(f3)) && break
-        # is x3 a solution? 
+        # is x3 a solution?
         abs(f3) < tol && return true
         # is x3 on the opposite side of the root?
         (f0 * f3 < 0.0) && return _do_bisect(x0, f0, x3, f3)

--- a/src/steadystate/diagnose.jl
+++ b/src/steadystate/diagnose.jl
@@ -20,7 +20,7 @@ the form of listing all bad equations and their residuals.
 
 ### Options
 Standard options (default values from `model.options`)
-  * `verbose` 
+  * `verbose`
   * `tol` - an equation is considered satisfied if its residual, in absolute
     value, is smaller than this number.
 
@@ -64,7 +64,7 @@ export diagnose_sstate
 Run diagnostics on the steady state of the given model. If `point` is not given,
 then we check the steady state solution stored inside the given model.
 
-Return a tuple of "bad" equations and "bad" variables. 
+Return a tuple of "bad" equations and "bad" variables.
 
 The set of "bad" equations is one that is inconsistent, i.e. there is no
 solution. This might happen if the system is overdetermined.
@@ -80,7 +80,7 @@ steady state constraints until you get a unique solution. See
 """
 diagnose_sstate(model::Model) = diagnose_sstate(model.sstate.values, model)
 function diagnose_sstate(point::AbstractVector{Float64}, model::Model)
-    tol = model.options.tol 
+    tol = model.options.tol
     rr, jj = global_SS_RJ(point, model)
     neqns, nvars = size(jj)
     ff = qr([jj Matrix(I, neqns, neqns); zeros(neqns, nvars) Matrix(I, neqns, neqns)], Val(true))

--- a/src/steadystate/lm.jl
+++ b/src/steadystate/lm.jl
@@ -38,8 +38,8 @@ Make an instance of the LMData for the given model. If solver data is not also
 given, then it is used, instead of creating a default SolverData for the model.
 """
 LMData(model::Model) = LMData(model, SolverData(model))
-LMData(model::Model, sd::SolverData) = LMData(sd, 
-                Array{Float64}(undef, sd.nvars, sd.nvars), 
+LMData(model::Model, sd::SolverData) = LMData(sd,
+                Array{Float64}(undef, sd.nvars, sd.nvars),
                 Array{Float64}(undef, sd.nvars),
                 Array{Float64}(undef, sd.nvars),
                 Array{Float64}(undef, sd.nvars),

--- a/src/steadystate/nr.jl
+++ b/src/steadystate/nr.jl
@@ -31,7 +31,7 @@ end
 
 NRData(model::Model; kwargs...) = NRData(model, SolverData(model); kwargs...)
 NRData(model::Model, sd::SolverData; linesearch::Bool = false) = NRData(sd, model.sstate,
-                    Array{Float64}(undef, sd.nvars), Array{Float64}(undef, sd.neqns), 
+                    Array{Float64}(undef, sd.nvars), Array{Float64}(undef, sd.neqns),
                     trues(sd.nvars), linesearch)
 
 """
@@ -48,7 +48,7 @@ function step_nr!(xx::AbstractArray{Float64,1}, dx::AbstractArray{Float64,1},
                     rr::AbstractArray{Float64,1}, jj::AbstractArray{Float64,2},
                     nr::NRData; verbose::Bool = false)
     ff = qr(jj, Val(true))  # deprecated as of Julia v1.7
-    # ff = qr(jj, ColumnNorm())  # does not work in Julia <= v1.6 
+    # ff = qr(jj, ColumnNorm())  # does not work in Julia <= v1.6
     rj = rank(ff.R)
     # nr.r_buffer .= ff.Q' * rr
     # dx[ff.p[1:rj]] = ff.R[1:rj,1:rj] \ nr.r_buffer[1:rj]

--- a/src/steadystate/presolve.jl
+++ b/src/steadystate/presolve.jl
@@ -63,7 +63,7 @@ function _presolve_equations!(eqns, mask, values, method, verbose, tol)
             unsolved = .!mask[sseqn.vinds]
             nunsolved = sum(unsolved)
             if nunsolved == 0
-                # all variables are solved, yet equation is not marked solved. 
+                # all variables are solved, yet equation is not marked solved.
                 # check if equation is satisfied
                 eqns_resid[eqn_idx] = R = sseqn.eval_resid(values[sseqn.vinds])
                 # mark it solved either way, but issue a warning if residual is not zero

--- a/src/steadystate/solverdata.jl
+++ b/src/steadystate/solverdata.jl
@@ -96,7 +96,7 @@ ignoring anything pre-solved.
   * `presolve::Bool` - if `false`, any pre-solved information is ignored and the
     solver data is set up to solve all equations for all variables.
 """
-function SolverData(model::Model; presolve::Bool=true, 
+function SolverData(model::Model; presolve::Bool=true,
             verbose::Bool=model.options.verbose,
             tol::Float64=model.options.tol
 )
@@ -201,7 +201,7 @@ function global_SS_RJ(point::AbstractVector{Float64}, sd::SolverData)
     for (i, (solve, ind, eqn)) in enumerate(zip(sd.solve_eqn, sd.eqns_index, sd.alleqns))
         solve || continue
         rr, jj = try
-            eqn.eval_RJ(sd.point[eqn.vinds]) 
+            eqn.eval_RJ(sd.point[eqn.vinds])
         catch
             (NaN64, fill(NaN64, size(eqn.vinds)))
         end
@@ -229,7 +229,7 @@ function global_SS_R!(resid::AbstractVector{Float64}, point::AbstractVector{Floa
     for (i, (solve, ind, eqn)) in enumerate(zip(sd.solve_eqn, sd.eqns_index, sd.alleqns))
         solve || continue
         rr = try
-            eqn.eval_resid(sd.point[eqn.vinds]) 
+            eqn.eval_resid(sd.point[eqn.vinds])
         catch
             NaN64
         end

--- a/src/steadystate/sssolve.jl
+++ b/src/steadystate/sssolve.jl
@@ -36,7 +36,7 @@ function sssolve!(model::Model;
     if method ∉ (:nr, :lm, :auto)
         error("Method should be one of :nr, :lm, or :auto, not :$method")
     end
-    
+
     ss = model.sstate
     ss_nvars = 2 * length(ss.vars)
     ss_neqns = ModelBaseEcon.neqns(ss)
@@ -52,7 +52,7 @@ function sssolve!(model::Model;
         # Nothing left to solve for
         return sd.point
     end
-    
+
     # nvars = length(model.sstate.mask)
     # vsyms = Symbol[ModelBaseEcon.ss_symbol(model.sstate, vi) for vi = 1:nvars]
     # presolved_var = vsyms[model.sstate.mask]

--- a/test/logsimtests.jl
+++ b/test/logsimtests.jl
@@ -22,10 +22,10 @@
 
         clear_sstate!(m)
         sssolve!(m)
-        @test m.sstate.X.level ≈ 1.0 
+        @test m.sstate.X.level ≈ 1.0
         @test m.sstate.X.slope ≈ m.rate
-        @test m.sstate.Y.level + 1 ≈ 0.0 + 1 
-        @test m.sstate.Y.slope + 1 ≈ m.rate + 1 
+        @test m.sstate.Y.level + 1 ≈ 0.0 + 1
+        @test m.sstate.Y.slope + 1 ≈ m.rate + 1
 
         p = Plan(m, 1U:10U)
 
@@ -39,7 +39,7 @@
             @test k[s] == d[s]
         end
         @test k.X[1U] ≈ 1.0
-        @test k.Y[1U] + 1 ≈ 1.0 
+        @test k.Y[1U] + 1 ≈ 1.0
         @test pct(k.X, -1) ≈ TSeries(p.range, (m.rate - 1) * 100)
         @test diff(k.Y) ≈ TSeries(p.range, m.rate)
 
@@ -50,7 +50,7 @@
         # no shocks
         ed.Ex .= 0.0
         ed.Ey .= 0.0
-        # initial 
+        # initial
         ed[firstdate(p)] = k[firstdate(p)]
 
         for fc in (fcgiven, fclevel, fcslope, fcnatural)
@@ -77,8 +77,8 @@
         sssolve!(m)
         @test m.sstate.X.level + 1 ≈ 1.0 + 1
         @test m.sstate.X.slope + 1 ≈ m.rate + 1
-        @test m.sstate.Y.level + 1 ≈ 0.0 + 1 
-        @test m.sstate.Y.slope + 1 ≈ m.rate + 1 
+        @test m.sstate.Y.level + 1 ≈ 0.0 + 1
+        @test m.sstate.Y.slope + 1 ≈ m.rate + 1
 
         p = Plan(m, 1U:10U)
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -14,7 +14,7 @@ end
 
 @testset "fcset" begin
     m = deepcopy(E7A.model)
-   
+
     empty!(m.sstate.constraints)
     @steadystate m lc = 1
     @steadystate m linv = 1

--- a/test/shockdecomp.jl
+++ b/test/shockdecomp.jl
@@ -106,7 +106,7 @@ using JLD2
     result3fo = shockdecomp(m, p, exog_data3; solver=:firstorder)
     @test compare(result3, result3fo; ignoremissing=true, atol=2^10 * eps(), quiet=true)
 
-    # additive for linearized model 
+    # additive for linearized model
     exog_data4 = copy(exog_data3)
     exog_data4[first(rng), m.shocks] .+= 0.1
     result4 = shockdecomp(m, p, exog_data4; control=result3.s, variant=:linearize, fctype=fcnatural)

--- a/test/sim_fo.jl
+++ b/test/sim_fo.jl
@@ -229,7 +229,7 @@ function test_initdecomp_stackedtime(m; nonlin=!m.linear, rng=2001Q1:2024Q4, fct
     p = Plan(m, rng)
     exog = steadystatedata(m, p)
     exog[begin:first(rng)-1, vars] = rand(m.maxlag, m.nvars)
-    # zero shocks 
+    # zero shocks
     ref = shockdecomp(m, p, exog; solver, fctype)
     for v in vars, s in shks
         @test norm(ref.sd[v][:, s], Inf) < atol

--- a/test/simdatatests.jl
+++ b/test/simdatatests.jl
@@ -47,11 +47,11 @@
         @test sd[:] == dta[:]
         @test sd[:a] isa TSeries && sd[:a].values == dta[:,1]
         @test sd["b"] isa TSeries && sd["b"].values == dta[:,2]
-        # 
+        #
         sd.a = dta[:,1]
         sd.b = dta[:,2]
         @test sd[:] == dta[:]
-        # 
+        #
         sd[:] = dta[:]
         sd.a = sd.b
         @test sd[:,1] == sd[:,2]
@@ -76,7 +76,7 @@
         @test_throws ArgumentError sd[2000Y]
         @test_throws BoundsError sd[1999Q4] = (a = 5.0, b = 1.1)
         @test_throws BoundsError sd[2010Q4] = rand(2)
-        # 
+        #
         @test sd[2001Q1:2002Q4] isa SimData
         @test sd[2001Q1:2002Q4] == sd[5:12,:]
         sd[2001Q1:2002Q4] = 1:16
@@ -90,9 +90,9 @@
         @test sd1[(:a,:c)] == sd1[:,[1,3]]
         # access with 2 args MIT and Symbol
         @test sd[2001Q2, (:a, :b)] isa NamedTuple
-        let foo = sd[2001Q2:2002Q1, (:a, :b)] 
+        let foo = sd[2001Q2:2002Q1, (:a, :b)]
             @test foo isa SimData
-            @test size(foo) == (4, 2) 
+            @test size(foo) == (4, 2)
             @test firstdate(foo) == 2001Q2
         end
         @test_throws BoundsError sd[1999Q1, (:a,)]
@@ -101,7 +101,7 @@
         @test similar(sd) isa typeof(sd)
         @test_throws BoundsError sd[1999Q1:2000Q4] = zeros(8, 2)
         @test_throws BoundsError sd[2004Q1:2013Q4, [:a, :b]]
-        # setindex with two 
+        # setindex with two
         sd[2001Q1, (:b,)] = 3.5
         @test sd[5,2] == 3.5
         sd[2000Q1:2001Q4, (:b,)] = 3.7

--- a/test/simtests.jl
+++ b/test/simtests.jl
@@ -47,11 +47,11 @@ function test_simulation(m_in, path; atol = 1.0e-9)
     m = deepcopy(m_in)
     nvars = ModelBaseEcon.nvariables(m)
     nshks = ModelBaseEcon.nshocks(m)
-    # 
+    #
     data_chk = readdlm(path, ',', Float64)
     IDX = size(data_chk, 1)
     plan = Plan(m, 1 + m.maxlag:IDX - m.maxlead)
-    # 
+    #
     p01 = deepcopy(plan)
     autoexogenize!(p01, m, m.maxlag + 1:IDX - m.maxlead)
     data01 = zeroarray(m, p01)
@@ -60,7 +60,7 @@ function test_simulation(m_in, path; atol = 1.0e-9)
     data01[m.maxlag + 1:end - m.maxlead,1:nvars] = data_chk[m.maxlag + 1:end - m.maxlead,1:nvars]
     res01 = simulate(m, p01, data01)
     @test isapprox(res01, data_chk; atol = atol)
-    
+
     p02 = deepcopy(plan)
     data02 = zeroarray(m, p02)
     data02[1:m.maxlag,:] = data_chk[1:m.maxlag,:]
@@ -92,7 +92,7 @@ function test_simulation(m_in, path; atol = 1.0e-9)
         end
     end
     res01_dev = simulate(m, p01, data01_dev; deviation=true)
-    @test isapprox(res01_dev, data_chk_dev; atol = atol) 
+    @test isapprox(res01_dev, data_chk_dev; atol = atol)
 end
 
 @testset "E1.sim" begin
@@ -115,7 +115,7 @@ end
 # linearization tests
 
 @testset "linearize" begin
-    m3 = deepcopy(E3.model) 
+    m3 = deepcopy(E3.model)
     clear_sstate!(m3)
     @test_throws ModelBaseEcon.LinearizationError linearize!(m3)
 
@@ -439,7 +439,7 @@ end
     # now attempt to recover shocks from solutions
     p_a2 = autoexogenize!(copy(p_a), m, test_rng)
     p_u2 = copy(p_a2)
-    # recover 
+    # recover
     chk_a = let data = copy(res_a)
         data.y_shk[test_rng] .= 100rand(length(test_rng))
         simulate(m, p_a2, data)
@@ -473,11 +473,11 @@ end
         clear_sstate!(m)
         nvars = ModelBaseEcon.nvariables(m)
         nshks = ModelBaseEcon.nshocks(m)
-        # 
+        #
         data_chk = readdlm("data/M3_TestData.csv", ',', Float64)
         IDX = size(data_chk, 1)
         plan = Plan(m, 1 + m.maxlag:IDX - m.maxlead)
-        # 
+        #
         p01 = deepcopy(plan)
         autoexogenize!(p01, m, m.maxlag + 1:IDX - m.maxlead)
         data01 = zeroarray(m, p01)
@@ -486,14 +486,14 @@ end
         data01[m.maxlag + 1:end - m.maxlead,1:nvars] = data_chk[m.maxlag + 1:end - m.maxlead,1:nvars]
         initial_guess = similar(data01)
         initial_guess .= 1
-        initial_guess[end-2:end,:] .= 0 #at the very end 
+        initial_guess[end-2:end,:] .= 0 #at the very end
         res01 = simulate(m, p01, data01)
         res01_line = nothing
         m.options.linesearch = true
         out = @capture_err begin
             res01_line = simulate(m, p01, data01; initial_guess=initial_guess, verbose=true)
         end
-      
+
         # line search should give the same results
         @test occursin("Linesearch success", out)
         @test isapprox(res01, data_chk; atol = 1.0e-9)
@@ -505,11 +505,11 @@ end
         clear_sstate!(m)
         nvars = ModelBaseEcon.nvariables(m)
         nshks = ModelBaseEcon.nshocks(m)
-        # 
+        #
         data_chk = readdlm("data/M1_TestData.csv", ',', Float64)
         IDX = size(data_chk, 1)
         plan = Plan(m, 1 + m.maxlag:IDX - m.maxlead)
-        # 
+        #
         p01 = deepcopy(plan)
         autoexogenize!(p01, m, m.maxlag + 1:IDX - m.maxlead)
         data01 = zeroarray(m, p01)
@@ -519,7 +519,7 @@ end
 
         # deviation gives the same results
         res01 = simulate(m, p01, data01)
-        res01_dev = simulate(m, p01, data01; deviation=true) 
+        res01_dev = simulate(m, p01, data01; deviation=true)
         @test isapprox(res01_dev, data_chk; atol = 1.0e-9)
         @test isapprox(res01_dev, res01; atol = 1.0e-9)
     end
@@ -528,11 +528,11 @@ end
         clear_sstate!(m)
         nvars = ModelBaseEcon.nvariables(m)
         nshks = ModelBaseEcon.nshocks(m)
-        # 
+        #
         data_chk = readdlm("data/M3_TestData.csv", ',', Float64)
         IDX = size(data_chk, 1)
         plan = Plan(m, 1 + m.maxlag:IDX - m.maxlead)
-        # 
+        #
         p01 = deepcopy(plan)
         autoexogenize!(p01, m, m.maxlag + 1:IDX - m.maxlead)
         data01 = zeroarray(m, p01)
@@ -543,7 +543,7 @@ end
         # deviation do not give the same result
         res01 = simulate(m, p01, data01)
         res01_dev = simulate(m, p01, data01; deviation=true)
-        @test isapprox(res01, data_chk; atol = 1.0e-9) 
+        @test isapprox(res01, data_chk; atol = 1.0e-9)
         @test !isapprox(res01_dev, data_chk; atol = 1.0e-9)
         @test !isapprox(res01_dev, res01; atol = 1.0e-9)
 
@@ -558,8 +558,8 @@ end
         res02 = simulate(m, p01, data02)
         res02_dev = simulate(m, p01, data02; deviation=true)
 
-        # results equal new data_chk02 
-        @test isapprox(res01, data_chk02; atol = 1.0e-9) 
+        # results equal new data_chk02
+        @test isapprox(res01, data_chk02; atol = 1.0e-9)
         @test isapprox(res02_dev, data_chk02; atol = 1.0e-9)
         @test isapprox(res02_dev, res01; atol = 1.0e-9)
 

--- a/test/sstests.jl
+++ b/test/sstests.jl
@@ -14,7 +14,7 @@ empty!(E1.model.sstate.constraints)
         sssolve!(m)
         @test check_sstate(m) == 0
         @test m.sstate.mask == [false, false, true, true]
-        # 
+        #
         @steadystate m y = 1.2
         m.α = 0.5
         m.β = 1.0 - m.α
@@ -23,7 +23,7 @@ empty!(E1.model.sstate.constraints)
         @test check_sstate(m) == 0
         @test m.sstate.mask == [true, false, true, true]
         @test m.sstate.values[1] == 1.2
-        # 
+        #
         m.α = 0.4
         m.β = 1.0 - m.α
         clear_sstate!(m)
@@ -32,7 +32,7 @@ empty!(E1.model.sstate.constraints)
         @test check_sstate(m) == 0
         @test m.sstate.mask == trues(4)
         @test m.sstate.values == [1.2, 0.0, 0.0, 0.0]
-        # 
+        #
         empty!(m.sstate.constraints)
         m.α = 0.3
         m.β = 1.0 - m.α
@@ -42,7 +42,7 @@ empty!(E1.model.sstate.constraints)
         end
         @test check_sstate(m) == 0
         @test m.sstate.values[2] == 0.0
-        # 
+        #
         empty!(m.sstate.constraints)
         m.α = 0.3
         m.β = 1.0 - m.α
@@ -60,7 +60,7 @@ empty!(E1.model.sstate.constraints)
         sssolve!(m; method=:auto)
         @test check_sstate(m) == 0
         @test m.sstate.mask == [true, true, true, true]  # different from default
-        # 
+        #
         @steadystate m y = 1.2
         m.α = 0.5
         m.β = 1.0 - m.α
@@ -69,7 +69,7 @@ empty!(E1.model.sstate.constraints)
         @test check_sstate(m) == 0
         @test m.sstate.mask == [true, true, true, true] # different from default
         @test m.sstate.values[1] == 1.2
-        # 
+        #
         m.α = 0.4
         m.β = 1.0 - m.α
         clear_sstate!(m)
@@ -78,7 +78,7 @@ empty!(E1.model.sstate.constraints)
         @test check_sstate(m) == 0
         @test m.sstate.mask == trues(4)
         @test m.sstate.values == [1.2, 0.0, 0.0, 0.0]
-        # 
+        #
         empty!(m.sstate.constraints)
         m.α = 0.3
         m.β = 1.0 - m.α
@@ -100,7 +100,7 @@ empty!(E1.model.sstate.constraints)
         sssolve!(m; method=:lm)
         @test check_sstate(m) == 0
         @test m.sstate.mask == [true, true, true, true]  # different from default
-        # 
+        #
         @steadystate m y = 1.2
         m.α = 0.5
         m.β = 1.0 - m.α
@@ -109,7 +109,7 @@ empty!(E1.model.sstate.constraints)
         @test check_sstate(m) == 0
         @test m.sstate.mask == [true, true, true, true]  # different from default
         @test m.sstate.values[1] == 1.2
-        # 
+        #
         m.α = 0.4
         m.β = 1.0 - m.α
         clear_sstate!(m)
@@ -118,7 +118,7 @@ empty!(E1.model.sstate.constraints)
         @test check_sstate(m) == 0
         @test m.sstate.mask == trues(4)
         @test m.sstate.values == [1.2, 0.0, 0.0, 0.0]
-        # 
+        #
         empty!(m.sstate.constraints)
         m.α = 0.3
         m.β = 1.0 - m.α
@@ -285,7 +285,7 @@ end
             @test check_sstate(m; verbose=true) == 6
         end
         @test occursin("System may be inconsistent", out)
-       
+
     end
 end
 
@@ -301,7 +301,7 @@ end
             c[t] = a[t] + b[t]
         end
         @initialize m
-        
+
         # tests
         @test sum(issteady.(m.allvars)) == 2
         clear_sstate!(m)
@@ -327,7 +327,7 @@ end
         @test check_sstate(m) == 0
         @test m.sstate.mask == [false, false, true, true]
     end
-    
+
     empty!(E1.model.sstate.constraints)
     let m = deepcopy(E1.model)
         m.α = 0.5


### PR DESCRIPTION
This commit removes trailing whitespace on all source files.

The main disadvantage is that it will complicate the git blame history and may make some merges of existing branches more of a hassle.

We may decide that these costs are not worth the marginal benefit of this cleanup.