### PR TITLE
Shift creation of sparse matrix out one level 

### DIFF
--- a/src/stackedtime/solverdata.jl
+++ b/src/stackedtime/solverdata.jl
@@ -274,9 +274,9 @@ function update_plan!(sd::StackedTimeSolverData, model::Model, plan::Plan; chang
                 append!(JJ, JJvar)
                 append!(VV, VVvar)
             end
-            # Construct the sparse matrix
-            sd.CiSc .= sparse(II, JJ, VV, NTFC * sd.NU, size(sd.J, 1))
         end
+        # Construct the sparse matrix
+        sd.CiSc .= sparse(II, JJ, VV, NTFC * sd.NU, size(sd.J, 1))
         # cached lu is no longer valid, since active columns have changed
         sd.J_factorized[] = nothing
     end


### PR DESCRIPTION
The current location of the sparse matrix creation seems to create new sparse matrix for every unknown.
But the location of where the sparse matrix is created is overwritten in every iteration so only the last sparse matrix will survive.
It should therefore be equivalent to only create the sparse matrix once, outside the loop.

Previously, in a simulation there were 768 calls to `sparse`

```
 Section            ncalls     time    %tot     avg     alloc    %tot      avg
 ────────────────────────────────────────────────────────────────────────────
   sparse              768    152ms   26.2%   198μs    557MiB   50.3%   743KiB
```

and after this there is only one.

```
 Section            ncalls     time    %tot     avg     alloc    %tot      avg
 ────────────────────────────────────────────────────────────────────────────
   sparse                1   64.1μs    0.0%  64.1μs    743KiB    0.1%   743KiB
```
