### PR TITLE
Support for stochastic simulations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ ForwardDiff = "0.10"
 JLD2 = "0.4"
 ModelBaseEcon = "0.5"
 Suppressor = "0.2"
-TimeSeriesEcon = "0.5"
+TimeSeriesEcon = "0.5.1"
 julia = "1.7"
 
 [extras]

--- a/src/Plans.jl
+++ b/src/Plans.jl
@@ -1,7 +1,7 @@
 ##################################################################################
 # This file is part of StateSpaceEcon.jl
 # BSD 3-Clause License
-# Copyright (c) 2020-2022, Bank of Canada
+# Copyright (c) 2020-2023, Bank of Canada
 # All rights reserved.
 ##################################################################################
 

--- a/src/Plans.jl
+++ b/src/Plans.jl
@@ -103,7 +103,9 @@ function Base.copyto!(dest::Plan, rng::AbstractUnitRange, scr::Plan)
     dest.varshks == scr.varshks || throw(ArgumentError("Both plans must have the same variables and shocks in the same order."))
     idx2 = axes(dest.exogenous, 2)  # same for both dest and scr
     copyto!(dest.exogenous, _offset(dest, rng), idx2, scr.exogenous, _offset(scr, rng), idx2)
+    return dest
 end
+
 Base.copyto!(dest::Plan, rng::MIT, scr::Plan) = Base.copyto!(dest, rng:rng, scr)
 Base.copyto!(dest::Plan, src::Plan) = Base.copyto!(dest, intersect(rangeof(dest), rangeof(src)), src)
 
@@ -134,8 +136,9 @@ end
 # A range with a model returns a plan trimmed over that range and extended for initial and final conditions.
 Base.getindex(p::Plan{MIT{Unit}}, rng::AbstractUnitRange{Int}, m::Model) = p[UnitRange{MIT{Unit}}(rng), m]
 @inline function Base.getindex(p::Plan{T}, rng::AbstractUnitRange{T}, m::Model) where {T<:MIT}
-    rng = (rng.start-m.maxlag):(rng.stop+m.maxlead)
-    return p[rng]
+    # rng = (rng.start-m.maxlag):(rng.stop+m.maxlead)
+    # return p[rng]
+    copyto!(Plan(m, rng), rng, p)
 end
 
 Base.setindex!(p::Plan, x, i...) = error("Cannot assign directly. Use `exogenize` and `endogenize` to alter plan.")

--- a/src/StackedTimeSolver.jl
+++ b/src/StackedTimeSolver.jl
@@ -29,6 +29,10 @@ import ..steadystatearray
 import ..SimData
 import ..rawdata
 
+import ..SimFailed
+import ..isfailed
+import ..MaybeSimData
+
 import ModelBaseEcon.hasevaldata
 import ModelBaseEcon.getevaldata
 import ModelBaseEcon.setevaldata!

--- a/src/StackedTimeSolver.jl
+++ b/src/StackedTimeSolver.jl
@@ -41,6 +41,7 @@ include("stackedtime/misc.jl")
 include("stackedtime/solverdata.jl")
 include("stackedtime/simulate.jl")
 include("stackedtime/shockdecomp.jl")
+include("stackedtime/stoch_simulate.jl")
 
 end # module
 

--- a/src/simdata.jl
+++ b/src/simdata.jl
@@ -1,7 +1,7 @@
 ##################################################################################
 # This file is part of StateSpaceEcon.jl
 # BSD 3-Clause License
-# Copyright (c) 2020-2022, Bank of Canada
+# Copyright (c) 2020-2023, Bank of Canada
 # All rights reserved.
 ##################################################################################
 

--- a/src/simdata.jl
+++ b/src/simdata.jl
@@ -168,6 +168,7 @@ Base.showerror(io::IO, ex::SimFailed) =
     print(io, "Simulation failed: $(ex.info)")
 isfailed(f::SimFailed)::Bool = !isnothing(f.info)
 isfailed(f::SimData)::Bool = false
+isfailed(f::Workspace)::Bool = false
 isfailed(f)::Bool = throw(ArgumentError("Unexpected $(typeof(f)) argument."))
 const MaybeSimData = Union{<:SimData,SimFailed}
 export SimFailed

--- a/src/simdata.jl
+++ b/src/simdata.jl
@@ -171,6 +171,7 @@ isfailed(f::SimData)::Bool = false
 isfailed(f::Workspace)::Bool = false
 isfailed(f)::Bool = throw(ArgumentError("Unexpected $(typeof(f)) argument."))
 const MaybeSimData = Union{<:SimData,SimFailed}
+Base.promote_rule(T::Type{<:SimData}, S::Type{<:SimFailed}) = Union{T, S}::Type
 export SimFailed
 export isfailed
 export MaybeSimData

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -202,10 +202,11 @@ function stoch_simulate(m::Model, p::Plan, baseline::SimData, shocks;
         shocks = [shocks]
     end
     # are shocks of the appropriate type
-    if (shocks isa AbstractVector || shocks isa Workspace || shocks isa AbstractDict) && (eltype(shocks) <: SimData)
-        nothing # we're okay
+    if ((shocks isa AbstractVector) && (eltype(shocks) <: SimData)) ||
+       ((shocks isa Workspace) && (Base.promote_typeof(values(shocks)...) <: SimData))
+        nothing
     else
-        throw(ArgumentError("Expected the shocks argument to be a collection of SimData, not $(typeof(shocks))."))
+        throw(ArgumentError("Expected the shocks argument to be Vector or Workspace of SimData, not $(typeof(shocks))."))
     end
     ##### dispatch
     getsolvermodule(solver).stoch_simulate(m, p, baseline[p.range], shocks; kwargs...)

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -21,15 +21,12 @@ const defaultsolver = :stackedtime
 
 Solve the given model and update its `m.solverdata` according to the specified
 solver.  The solver is specified as a `Symbol`.  The default is `solve=:stackedtime`.
-
-`solver=:firstorder` is experimental.
-
 """
 function solve! end
 export solve!
 
 function solve!(model::Model; solver::Symbol=defaultsolver, kwargs...)
-  return getsolvermodule(solver).solve!(model; kwargs...)
+    return getsolvermodule(solver).solve!(model; kwargs...)
 end
 
 #####  shockdecomp() #####
@@ -62,9 +59,9 @@ function shockdecomp end
 export shockdecomp
 
 function shockdecomp(model::Model, plan::Plan, exogdata::MVTSeries;
-  solver::Symbol=defaultsolver, initdecomp::Workspace=Workspace(),
-  control::MVTSeries=steadystatedata(model, plan), kwargs...)
-  return getsolvermodule(solver).shockdecomp(model, plan, exogdata; control, initdecomp, kwargs...)
+    solver::Symbol=defaultsolver, initdecomp::Workspace=Workspace(),
+    control::MVTSeries=steadystatedata(model, plan), kwargs...)
+    return getsolvermodule(solver).shockdecomp(model, plan, exogdata; control, initdecomp, kwargs...)
 end
 
 #####  simulate() #####
@@ -75,82 +72,143 @@ end
 Run a simulation for the given model, simulation plan and exogenous data.
 
 ### Arguments
-  * `model` - the [`Model`](@ref ModelBaseEcon.Model) instance to simulate.
-  * `plan` - the [`Plan`](@ref) for the simulation.
-  * `data` - a 2D `Array` containing the exogenous data. This includes the
-    initial and final conditions.
+    * `model` - the [`Model`](@ref ModelBaseEcon.Model) instance to simulate.
+    * `plan` - the [`Plan`](@ref) for the simulation.
+    * `data` - a 2D `Array` containing the exogenous data. This includes the
+        initial and final conditions.
 
 ### Options as keyword arguments
-  * `fctype::`[`FinalCondition`](@ref) - set the desired final condition type
-    for the simulation. The default value is [`fcgiven`](@ref). Other possible
-    values include [`fclevel`](@ref), [`fcslope`](@ref) and
-    [`fcnatural`](@ref).
-  * `initial_guess::AbstractMatrix{Float64}` - a 2D `Array` containing the
-    initial guess for the solution. This is used to start the Newton-Raphson
-    algorithm. The default value is an empty array (`zeros(0,0)`), in which case
-    we use the exogenous data for the initial condition. You can use the steady
-    state solution using [`steadystatearray`](@ref).
-  * `deviation::Bool` - set to `true` if the `data` is given in deviations from
-    the steady state. In this case the simulation result is also returned as a
-    deviation from the steady state. Default value is `false`.
-  * `anticipate::Bool` - set to `false` to instruct the solver that all shocks
-    are unanticipated by the agents. Default value is `true`.
-  * `verbose::Bool` - control whether or not to print progress information.
-    Default value is taken from `model.options`.
-  * `tol::Float64` - set the desired accuracy. Default value is taken from
-    `model.options`.
-  * `maxiter::Int` - algorithm fails if the desired accuracy is not reached
-    within this maximum number of iterations. Default value is taken from
-    `model.options`.
-  * `linesearch::Bool` - When `true` the Newton-Raphson is modified to include a
-    search along the descent direction for a sufficient decrease in f. It will
-    do this at each iteration. Default is `false`.
+    * `fctype::`[`FinalCondition`](@ref) - set the desired final condition type
+        for the simulation. The default value is [`fcgiven`](@ref). Other possible
+        values include [`fclevel`](@ref), [`fcslope`](@ref) and
+        [`fcnatural`](@ref).
+    * `initial_guess::AbstractMatrix{Float64}` - a 2D `Array` containing the
+        initial guess for the solution. This is used to start the Newton-Raphson
+        algorithm. The default value is an empty array (`zeros(0,0)`), in which case
+        we use the exogenous data for the initial condition. You can use the steady
+        state solution using [`steadystatearray`](@ref).
+    * `deviation::Bool` - set to `true` if the `data` is given in deviations from
+        the steady state. In this case the simulation result is also returned as a
+        deviation from the steady state. Default value is `false`.
+    * `anticipate::Bool` - set to `false` to instruct the solver that all shocks
+        are unanticipated by the agents. Default value is `true`.
+    * `verbose::Bool` - control whether or not to print progress information.
+        Default value is taken from `model.options`.
+    * `tol::Float64` - set the desired accuracy. Default value is taken from
+        `model.options`.
+    * `maxiter::Int` - algorithm fails if the desired accuracy is not reached
+        within this maximum number of iterations. Default value is taken from
+        `model.options`.
+    * `linesearch::Bool` - When `true` the Newton-Raphson is modified to include a
+        search along the descent direction for a sufficient decrease in f. It will
+        do this at each iteration. Default is `false`.
 """
 function simulate end
 export simulate
 
 # The versions of simulate with Dict/Workspace -> convert to SimData
 simulate(m::Model, p::Plan, data::Union{Workspace,AbstractDict}; kwargs...) =
-  simulate(m, p, workspace2data(TimeSeriesEcon._dict_to_workspace(data), m, p; copy=true); kwargs...)
+    simulate(m, p, workspace2data(TimeSeriesEcon._dict_to_workspace(data), m, p; copy=true); kwargs...)
 
 simulate(m::Model, p_ant::Plan, data_ant::Union{Workspace,AbstractDict},
-  p_unant::Plan, data_unant::Union{Workspace,AbstractDict}; kwargs...) =
-  simulate(m, p_ant, workspace2data(TimeSeriesEcon._dict_to_workspace(data_ant), m, p_ant; copy=true),
-    p_unant, workspace2data(TimeSeriesEcon._dict_to_workspace(data_unant), m, p_unant; copy=true), ;
-    kwargs...)
+    p_unant::Plan, data_unant::Union{Workspace,AbstractDict}; kwargs...) =
+    simulate(m, p_ant, workspace2data(TimeSeriesEcon._dict_to_workspace(data_ant), m, p_ant; copy=true),
+        p_unant, workspace2data(TimeSeriesEcon._dict_to_workspace(data_unant), m, p_unant; copy=true), ;
+        kwargs...)
 
 function _initial_guess_to_array(initial_guess, m, p)
-  return initial_guess isa SimData ? (; initial_guess=data2array(initial_guess, m, p)) :
-         initial_guess isa Workspace ? (; initial_guess=workspace2array(initial_guess, m, p)) :
-         initial_guess isa AbstractDict ? (; initial_guess=workspace2array(Workspace(initial_guess), m, p)) :
-         (;)
+    return initial_guess isa SimData ? (; initial_guess=data2array(initial_guess, m, p)) :
+           initial_guess isa Workspace ? (; initial_guess=workspace2array(initial_guess, m, p)) :
+           initial_guess isa AbstractDict ? (; initial_guess=workspace2array(Workspace(initial_guess), m, p)) :
+           (;)
 end
 
 # Handle initial conditions and assign result only within the plan range (in case range of given data is larger)
 function simulate(m::Model, p::Plan, data::SimData; kwargs...)
-  exog = data2array(data, m, p)
-  kw_ig = _initial_guess_to_array(get(kwargs, :initial_guess, nothing), m, p)
-  result = copy(data)
-  result[p.range, m.varshks] .= simulate(m, p, exog; kwargs..., kw_ig...)
-  return result
+    exog = data2array(data, m, p)
+    kw_ig = _initial_guess_to_array(get(kwargs, :initial_guess, nothing), m, p)
+    result = copy(data)
+    result[p.range, m.varshks] .= simulate(m, p, exog; kwargs..., kw_ig...)
+    return result
 end
 
 # this is the dispatcher -> call the appropriate solver
 simulate(m::Model, p::Plan, exog::AbstractMatrix; solver::Symbol=defaultsolver, kwargs...) =
-  getsolvermodule(solver).simulate(m, p, exog; kwargs...)
+    getsolvermodule(solver).simulate(m, p, exog; kwargs...)
 
 # Handle the case with 2 sets of plan-data for mixture of ant and unant shocks
 function simulate(m::Model, p_ant::Plan, data_ant::SimData, p_unant::Plan, data_unant::SimData; kwargs...)
-  exog_ant = data2array(data_ant)
-  exog_unant = data2array(data_unant)
-  kw_ig = _initial_guess_to_array(get(kwargs, :initial_guess, nothing), m, p_ant)
-  result = copy(data_ant)
-  result[p_ant.range, m.varshks] .= simulate(m, p_ant, exog_ant, p_unant, exog_unant; kwargs..., kw_ig...)
-  return result
+    exog_ant = data2array(data_ant)
+    exog_unant = data2array(data_unant)
+    kw_ig = _initial_guess_to_array(get(kwargs, :initial_guess, nothing), m, p_ant)
+    result = copy(data_ant)
+    result[p_ant.range, m.varshks] .= simulate(m, p_ant, exog_ant, p_unant, exog_unant; kwargs..., kw_ig...)
+    return result
 end
 
 # this is the dispatcher -> call the appropriate solver
 simulate(m::Model, p_ant::Plan, data_ant::AbstractMatrix,
-  p_unant::Plan, data_unant::AbstractMatrix;
-  solver::Symbol=defaultsolver, kwargs...) =
-  getsolvermodule(solver).simulate(m, p_ant, data_ant, p_unant, data_unant; kwargs...)
+    p_unant::Plan, data_unant::AbstractMatrix;
+    solver::Symbol=defaultsolver, kwargs...) =
+    getsolvermodule(solver).simulate(m, p_ant, data_ant, p_unant, data_unant; kwargs...)
+
+
+#####  stoch_simulate() #####
+
+"""
+    stoch_simulate(model, plan, baseline, shocks; control, ...)
+
+Run multiple simulations with the given shocks centered about the given control
+(steady state by default).
+
+The baseline should span the plan range and must be given in levels ( i.e., option deviation=true is not implemented)
+
+The shocks can be given as a collection of random realizations, where each
+realization could be an MVTSeries or a Workspace. Only the shocks should be
+provided.
+
+All shock names must be exogenous in the given plan over the range of the given
+data. The data in `control` is taken as anticipated and the stochastic
+realizations are taken as unanticipated and the same plan is used for both
+components.
+
+Currently only the case of `solver=stackedtime` is implemented.
+
+"""
+function stoch_simulate end
+
+
+######## make sure the baseline argument is a SimData
+
+# convert baseline from Workspace to SimData
+function stoch_simulate(m::Model, p::Plan, baseline::Workspace, shocks; kwargs...)
+    baseline = copyto!(MVTSeries(p.range, m.allvars), baseline)
+    return stoch_simulate(m, p, baseline, shocks; kwargs...)
+end
+
+# convert baseline from Matrix to SimData
+function stoch_simulate(m::Model, p::Plan, baseline::AbstractMatrix, shocks; kwargs...)
+    baseline = copyto!(MVTSeries(p.range, m.allvars), baseline)
+    return stoch_simulate(m, p, baseline, shocks; kwargs...)
+end
+
+######## dispatcher
+function stoch_simulate(m::Model, p::Plan, baseline::SimData, shocks;
+    solver::Symbol=defaultsolver,
+    kwargs...
+)
+    ##### check shocks
+    if shocks isa SimData && eltype(shocks) == Float64
+        shocks = [shocks]
+    end
+    # are shocks of the appropriate type
+    if (shocks isa AbstractVector || shocks isa Workspace || shocks isa AbstractDict) && (eltype(shocks) <: SimData)
+        nothing # we're okay
+    else
+        throw(ArgumentError("Expected the shocks argument to be a collection of SimData, not $(typeof(shocks))."))
+    end
+    ##### dispatch
+    getsolvermodule(solver).stoch_simulate(m, p, baseline, shocks; kwargs...)
+end
+export stoch_simulate
+

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -208,7 +208,7 @@ function stoch_simulate(m::Model, p::Plan, baseline::SimData, shocks;
         throw(ArgumentError("Expected the shocks argument to be a collection of SimData, not $(typeof(shocks))."))
     end
     ##### dispatch
-    getsolvermodule(solver).stoch_simulate(m, p, baseline, shocks; kwargs...)
+    getsolvermodule(solver).stoch_simulate(m, p, baseline[p.range], shocks; kwargs...)
 end
 export stoch_simulate
 

--- a/src/stackedtime/simulate.jl
+++ b/src/stackedtime/simulate.jl
@@ -1,7 +1,7 @@
 ##################################################################################
 # This file is part of StateSpaceEcon.jl
 # BSD 3-Clause License
-# Copyright (c) 2020-2022, Bank of Canada
+# Copyright (c) 2020-2023, Bank of Canada
 # All rights reserved.
 ##################################################################################
 

--- a/src/stackedtime/simulate.jl
+++ b/src/stackedtime/simulate.jl
@@ -259,7 +259,7 @@ function simulate(m::Model,
                 end
             end
         else
-            # when expectation_horizon is not given,
+            # when expectation_horizon is given,
             # the first and last simulations use the true 
             # simulation range and final condition, while the intermediate 
             # simulations use expectation_horizon steps with fcnatural

--- a/src/stackedtime/solverdata.jl
+++ b/src/stackedtime/solverdata.jl
@@ -49,7 +49,7 @@ struct StackedTimeSolverData # <: AbstractSolverData
     solve_mask::AbstractVector{Bool}
     "Cache the factorization of the active part of J"
     J_factorized::Ref{Any}
-    "Set to one of :qr or :lm"
+    "Set to one of :qr or :lu"
     factorization::Symbol
 end
 

--- a/src/stackedtime/stoch_simulate.jl
+++ b/src/stackedtime/stoch_simulate.jl
@@ -1,0 +1,151 @@
+##################################################################################
+# This file is part of StateSpaceEcon.jl
+# BSD 3-Clause License
+# Copyright (c) 2020-2023, Bank of Canada
+# All rights reserved.
+##################################################################################
+
+# version of simulate for stochastic simulations 
+
+
+function _make_result_container(shocks::Workspace, basedata)
+    w = Workspace()
+    for key in keys(shocks)
+        push!(w, key => copy(basedata))
+    end
+    return w
+end
+
+function _make_result_container(shocks::Vector, basedata)
+    return map(copy, Iterators.repeated(basedata, length(shocks)))
+end
+
+function stoch_simulate(m::Model, p::Plan, baseline::SimData, shocks;
+    check::Bool=false,
+    #= Solver options =#
+    variant::Symbol=m.options.variant,
+    verbose::Bool=m.options.verbose,
+    tol::Float64=m.options.tol,
+    maxiter::Int=m.options.maxiter,
+    fctype=getoption(m, :fctype, fcgiven),
+    #= Newton-Raphson options =#
+    sparse_solver::Function=\,
+    linesearch::Bool=getoption(m, :linesearch, false),
+    warn_maxiter::Bool=getoption(getoption(m, :warn, Options()), :maxiter, false)
+)
+
+    # get the range of all shocks realizations (this will be the full simulation range)
+    shkrng = mapreduce(rangeof, union, values(shocks))
+
+    # are all shocks in the same range
+    same_range = all(==(shkrng) ∘ rangeof, shocks)
+
+    # make sure the plan range contains shkrng 
+    if firstdate(p) + m.maxlag > first(shkrng)
+        throw(ArgumentError("Simulation starts too late for the given shocks realizations."))
+    end
+    if last(shkrng) > lastdate(p) - m.maxlead
+        throw(ArgumentError("Simulation ends too early for the given shocks realizations."))
+    end
+    if last(shkrng) > lastdate(p) - m.maxlead - 20  # why 20? 
+        @warn "Simulation may be too short - allow at least 20 periods after the last shock."
+    end
+
+    # make sure all given stochastic shocks are exogenous during their stochastic ranges
+    for (key, value) in pairs(shocks)
+        for (shk, val) in pairs(value)
+            tinds = Plans._offset(p, rangeof(val))
+            vind = p.varshks[shk]
+            if !all(p.exogenous[tinds, vind])
+                throw(ArgumentError("$shk in shocks realization $key is endogenous in the given plan."))
+            end
+        end
+    end
+
+    # make sure the model evaluation data is up to date
+    refresh_med!(m, variant)
+
+    # prepare the baseline data
+    e₀ = ModelBaseEcon.update_auxvars(transform(baseline, m), m)
+
+    if check
+        ### Anticipated run
+        # the plan
+        local p₀ = copy(p)
+        # the solver data
+        local d₀ = StackedTimeSolverData(m, p₀, fctype, variant)
+
+        # we assume that baseline is the anticipated solution. let's check 
+        local res = Vector{Float64}(undef, size(d₀.J, 1))
+        stackedtime_R!(res, e₀, e₀, d₀)
+        local nres = norm(res, Inf)
+        if nres >= tol
+            throw(ArgumentError("The given baseline is not a solution: residual $nres > tolerance $tol."))
+        end
+    end
+
+    ### Unanticipated stochastic shocks
+
+    # range for the result
+    resrng = first(shkrng)-m.maxlag:last(p.range)
+
+    # allocate results 
+    results = _make_result_container(shocks, e₀[resrng, m.varshks])
+
+    # last simulation period, excluding final conditions periods
+    sim_end = lastdate(p) - m.maxlead
+
+    # the time loop
+    for i = eachindex(shkrng)
+        t = shkrng[i]
+
+        # simulation range for this period
+        # rₜ = t:sim_end
+
+        # simulation plan is a view into the full plan
+        pₜ = let
+            i1 = Plans._offset(p, t) - m.maxlag
+            i2 = lastindex(p.exogenous, 1)
+            Plan{typeof(t)}(t-m.maxlag:lastdate(p), p.varshks, view(p.exogenous, i1:i2, :))
+        end
+
+        # solver data 
+        dₜ = StackedTimeSolverData(m, pₜ, fctype, variant)
+
+        # the shocks realizations loop
+        for ((skey, shock), (rkey, result)) in zip(pairs(shocks), pairs(results))
+            @assert skey == rkey
+
+            # skip if t is outside the range of shock
+            same_range || firstdate(shock) ≤ t ≤ lastdate(shock) || continue
+
+            verbose && @info "Simulating $skey over $(t:sim_end)."
+
+            # create a view into the result for this period
+            eₜ = view(result, pₜ.range, :)
+
+            # assign unanticipated shocks
+            eₜ[t, axes(shock, 2)] .+= shock[t, :]   # 
+
+            # solve 
+            converged = sim_nr!(eₜ, dₜ, maxiter, tol, verbose, sparse_solver, linesearch)
+            if warn_maxiter && !converged
+                @warn("Newton-Raphson reached maximum number of iterations for $skey at $(t:sim_end)")
+            end
+
+        end # shocks loop 
+
+    end # time loop
+
+    # strip auxvar columns and inverse transform
+    for (key, result) in pairs(results)
+        if m.nauxs > 0
+            result = result[:, m.varshks]
+        end
+        results[key] = inverse_transform(result, m)
+    end
+
+    return results
+end
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 ##################################################################################
 # This file is part of StateSpaceEcon.jl
 # BSD 3-Clause License
-# Copyright (c) 2020-2022, Bank of Canada
+# Copyright (c) 2020-2023, Bank of Canada
 # All rights reserved.
 ##################################################################################
 
@@ -221,3 +221,5 @@ include("sim_fo.jl")
 include("shockdecomp.jl")
 include("dynss.jl")
 include("misc.jl")
+
+include("stochsims.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,7 +141,7 @@ end
 
 end
 
-# include("simdatatests.jl")
+include("simdatatests.jl")
 include("sstests.jl")
 
 @testset "misc" begin

--- a/test/simdatatests.jl
+++ b/test/simdatatests.jl
@@ -147,3 +147,28 @@ end
         end
     end
 end
+
+@testset "simdata mv" begin
+    data = SimData(2020Q1:2030Q1-1, (:a, :b, :c), randn)
+    a = ModelVariable(:a)
+    b = ModelVariable(:b)
+    c = ModelVariable(:c)
+
+    @test data[:a] === data[a]
+    @test data[(:a, :b)] == data[(a, b)]
+    @test (data[c] = fill(1, size(data.c)); all(data.c .== 1))
+    @test (data[[a,b]] = fill(2, (size(data,1),2)); all(data.a .== 2) && all(data.b .== 2))
+    @test @view(data[:, a]) == @view(data[:, :a])
+end
+
+@testset "SimFailed" begin
+    foo = SimData(2020Q1, (:a, :b, :c), randn(10,3))
+    bar = SimFailed(21)
+    @test isfailed(foo) == false
+    @test isfailed(bar) == true
+    @test isfailed(Workspace()) == false
+    @test eltype([foo, bar]) <: MaybeSimData
+    @test_throws SimFailed throw(bar)
+    @test isfailed.([foo, bar, foo]) == [false, true, false]
+end
+

--- a/test/simdatatests.jl
+++ b/test/simdatatests.jl
@@ -1,7 +1,7 @@
 ##################################################################################
 # This file is part of StateSpaceEcon.jl
 # BSD 3-Clause License
-# Copyright (c) 2020, Bank of Canada
+# Copyright (c) 2020-2023, Bank of Canada
 # All rights reserved.
 ##################################################################################
 
@@ -10,15 +10,15 @@
     let nms = (:a, :b), dta = rand(20, 2), sd = SimData(2000Q1, nms, copy(dta)), dta2 = rand(size(dta)...)
         @test firstdate(sd) == 2000Q1
         @test lastdate(sd) == 2000Q1 + 20 - 1
-        @test frequencyof(sd) == Quarterly
+        @test isquarterly(sd)
         @test sd isa AbstractMatrix
         @test size(sd) == size(dta)
         # integer indexing must be identical to dta
         for i in axes(dta, 2)
-            @test sd[:,i] == dta[:,i]
+            @test sd[:, i] == dta[:, i]
         end
         for j in axes(dta, 1)
-            @test sd[j,:] == dta[j,:]
+            @test sd[j, :] == dta[j, :]
         end
         for i in eachindex(dta)
             @test sd[i] == dta[i]
@@ -29,11 +29,11 @@
         end
         @test sd[:] == dta2[:]
         for i in axes(dta, 1)
-            sd[i,:] = dta[i,:]
+            sd[i, :] = dta[i, :]
         end
         @test sd[:] == dta[:]
         for i in axes(dta2, 2)
-            sd[:,i] = dta2[:,i]
+            sd[:, i] = dta2[:, i]
         end
         @test sd[:] == dta2[:]
         # access by dot notation (for the columns)
@@ -41,58 +41,52 @@
         @test sd.a isa TSeries
         @test sd.b isa TSeries
         @test_throws BoundsError sd.c
-        @test sd.a.values == dta2[:,1]
-        sd.a[:] = dta[:,1]
-        sd.b[:] = dta[:,2]
+        @test sd.a.values == dta2[:, 1]
+        sd.a[:] = dta[:, 1]
+        sd.b[:] = dta[:, 2]
         @test sd[:] == dta[:]
-        @test sd[:a] isa TSeries && sd[:a].values == dta[:,1]
-        @test sd["b"] isa TSeries && sd["b"].values == dta[:,2]
+        @test sd[:a] isa TSeries && sd[:a].values == dta[:, 1]
+        @test sd["b"] isa TSeries && sd["b"].values == dta[:, 2]
         # 
-        sd.a = dta[:,1]
-        sd.b = dta[:,2]
+        sd.a = dta[:, 1]
+        sd.b = dta[:, 2]
         @test sd[:] == dta[:]
         # 
         sd[:] = dta[:]
         sd.a = sd.b
-        @test sd[:,1] == sd[:,2]
+        @test sd[:, 1] == sd[:, 2]
         sd.a = zeros(size(dta, 1))
         @test sum(abs, sd.a.values) == 0
         @test_throws BoundsError sd.a = ones(length(sd.a) + 5)
         # access to rows by MIT
         sd[:] = dta[:]
-        @test sd[2000Q1] isa NamedTuple{nms,NTuple{length(nms),Float64}}
-        for (i, idx) in enumerate(mitrange(sd))
-            @test [values(sd[idx])...] == dta[i,:]
+        @test sd[2000Q1] isa Vector{Float64}
+        for (i, idx) in enumerate(rangeof(sd))
+            @test [values(sd[idx])...] == dta[i, :]
         end
         sd[2000Q1] = zeros(size(dta, 2))
-        @test sum(abs, sd[1,:]) == 0
+        @test sum(abs, sd[1, :]) == 0
         @test_throws BoundsError sd[1999Q4]
         @test_throws DimensionMismatch sd[2000Q3] = zeros(size(dta, 2) + 1)
-        sd[2000Q2] = (b = 7.0, a = 1.5)
-        @test sd[2,:] == [1.5, 7.0]
-        sd[2004Q4] = (a = 5.0,)
-        @test sd[end,1] == 5.0
-        @test_throws BoundsError sd[2004Q4] = (a = 5.0, c = 1.1)
         @test_throws ArgumentError sd[2000Y]
-        @test_throws BoundsError sd[1999Q4] = (a = 5.0, b = 1.1)
         @test_throws BoundsError sd[2010Q4] = rand(2)
         # 
         @test sd[2001Q1:2002Q4] isa SimData
-        @test sd[2001Q1:2002Q4] == sd[5:12,:]
+        @test sd[2001Q1:2002Q4] ≈ sd[5:12, :]
         sd[2001Q1:2002Q4] = 1:16
-        @test sd[5:12,:] == reshape(1.0:16.0, :, 2)
+        @test sd[5:12, :] == reshape(1.0:16.0, :, 2)
         @test_throws BoundsError sd[1111Q4:2002Q1]
         @test_throws BoundsError sd[2002Q1:2200Q2]
         @test_throws DimensionMismatch sd[2001Q1:2002Q4] = 1:17
         # assign new column
-        sd1 = hcat(sd, c=sd.a + 3.0)
+        sd1 = hcat(sd, c=sd.a .+ 3.0)
         @test sd1[nms] == sd
-        @test sd1[(:a,:c)] == sd1[:,[1,3]]
+        @test sd1[(:a, :c)] ≈ sd1[:, [1, 3]]
         # access with 2 args MIT and Symbol
-        @test sd[2001Q2, (:a, :b)] isa NamedTuple
-        let foo = sd[2001Q2:2002Q1, (:a, :b)] 
+        @test sd[2001Q2, (:a, :b)] isa Vector{Float64}
+        let foo = sd[2001Q2:2002Q1, (:a, :b)]
             @test foo isa SimData
-            @test size(foo) == (4, 2) 
+            @test size(foo) == (4, 2)
             @test firstdate(foo) == 2001Q2
         end
         @test_throws BoundsError sd[1999Q1, (:a,)]
@@ -102,10 +96,10 @@
         @test_throws BoundsError sd[1999Q1:2000Q4] = zeros(8, 2)
         @test_throws BoundsError sd[2004Q1:2013Q4, [:a, :b]]
         # setindex with two 
-        sd[2001Q1, (:b,)] = 3.5
-        @test sd[5,2] == 3.5
-        sd[2000Q1:2001Q4, (:b,)] = 3.7
-        @test all(sd[1:8,2] .== 3.7)
+        sd[2001Q1, (:b,)] = [3.5]
+        @test sd[5, 2] == 3.5
+        sd[2000Q1:2001Q4, (:b,)] .= 3.7
+        @test all(sd[1:8, 2] .== 3.7)
         @test_throws BoundsError sd[1999Q1:2000Q4, (:a, :b)] = 5.7
         @test_throws BoundsError sd[2000Q1:2000Q4, (:a, :c)] = 5.7
     end
@@ -114,13 +108,13 @@ end
 
 @testset "SimData show" begin
     # test the case when column labels are longer than the numbers
-    let io = IOBuffer(), sd =  SimData(1U, (:verylongandsuperboringnameitellya, :anothersuperlongnamethisisridiculous, :a), rand(20, 3) .* 100)
+    let io = IOBuffer(), sd = SimData(1U, (:verylongandsuperboringnameitellya, :anothersuperlongnamethisisridiculous, :a), rand(20, 3) .* 100)
         show(io, sd)
         lines = readlines(seek(io, 0))
         # labels longer than 10 character are abbreviated with '…' at the end
         @test length(split(lines[2], '…')) == 3
     end
-    let io = IOBuffer() , sd = SimData(1U, (:alpha, :beta), zeros(24, 2))
+    let io = IOBuffer(), sd = SimData(1U, (:alpha, :beta), zeros(24, 2))
         show(io, sd)
         lines = readlines(seek(io, 0))
         lens = length.(lines)
@@ -129,8 +123,8 @@ end
     end
     nrow = 24
     letters = Symbol.(['a':'z'...])
-    for (nlines, fd) = zip([3, 4, 5, 6, 7, 8, 22, 23, 24, 25, 26, 30], Iterators.cycle((qq(2010, 1), mm(2010, 1), yy(2010), ii(1))))
-        for ncol = [2,5,10,20]
+    for (nlines, fd) = zip([3, 4, 5, 6, 7, 8, 22, 23, 24, 25, 26, 30], Iterators.cycle((2010Q1, 2010M1, 2010Y, 1U)))
+        for ncol = [2, 5, 10, 20]
             # display size if nlines × 80
             # data size is nrow × ncol
             # when printing data there are two header lines - summary and column names
@@ -155,14 +149,14 @@ end
     c = ModelVariable(:c)
 
     @test data[:a] === data[a]
-    @test data[(:a, :b)] == data[(a, b)]
+    @test data[(:a, :b)] == data[[a, b]]
     @test (data[c] = fill(1, size(data.c)); all(data.c .== 1))
-    @test (data[[a,b]] = fill(2, (size(data,1),2)); all(data.a .== 2) && all(data.b .== 2))
+    @test (data[[a, b]] = fill(2, (size(data, 1), 2)); all(data.a .== 2) && all(data.b .== 2))
     @test @view(data[:, a]) == @view(data[:, :a])
 end
 
 @testset "SimFailed" begin
-    foo = SimData(2020Q1, (:a, :b, :c), randn(10,3))
+    foo = SimData(2020Q1, (:a, :b, :c), randn(10, 3))
     bar = SimFailed(21)
     @test isfailed(foo) == false
     @test isfailed(bar) == true

--- a/test/stochsims.jl
+++ b/test/stochsims.jl
@@ -60,10 +60,10 @@
     end
 
     # try with Workspace
-    # shk_w = Workspace(Symbol(:s, i) => shk_sample[i] for i in eachindex(shk_sample))
-    # res_w = stoch_simulate(m, plan, db_1, shk_w)
-    # for i in eachindex(shk_sample)
-    #     @test res_w[Symbol(:s, i)] ≈ res[i]
-    # end
+    shk_w = Workspace(Symbol.(:s, eachindex(shk_sample)) .=> shk_sample)
+    res_w = stoch_simulate(m, plan, db_1, shk_w)
+    for i in eachindex(shk_sample)
+        @test res_w[Symbol(:s, i)] ≈ res[i]
+    end
 
 end

--- a/test/stochsims.jl
+++ b/test/stochsims.jl
@@ -1,0 +1,57 @@
+##################################################################################
+# This file is part of StateSpaceEcon.jl
+# BSD 3-Clause License
+# Copyright (c) 2020-2023, Bank of Canada
+# All rights reserved.
+##################################################################################
+
+@using_example E6
+
+@testset "stochsims" begin
+    m = deepcopy(E6.model)
+    m.options.fctype = fcnatural
+    @steadystate m lp = 0.6
+    @steadystate m ly = 0.3
+    @steadystate m lyn = 011
+    clear_sstate!(m)
+    sssolve!(m)
+    @test issssolved(m)
+    plan = Plan(m, 1U:50U)
+    db_ss = steadystatedata(m, plan)
+    @test db_ss ≈ simulate(m, plan, db_ss; anticipate=true)
+
+    srng = 1U:5U
+
+    shk_sample = [
+        MVTSeries(srng, m.shocks, rand),
+        MVTSeries(srng, m.shocks, rand),
+        MVTSeries(srng, m.shocks, rand),
+        MVTSeries(srng, m.shocks, rand)
+    ]
+
+    res = stoch_simulate(m, plan, db_ss, shk_sample)
+    for (r, s) in zip(res, shk_sample)
+        tmp = copy(db_ss)
+        tmp .= tmp .+ s
+        @test !(r ≈ simulate(m, plan, tmp))
+        @test (r ≈ simulate(m, plan, tmp; anticipate=false))
+    end
+
+    # baseline that is not the steady state
+    db_1 = copy(db_ss)
+    db_1 .= db_1 .+ MVTSeries(srng, m.shocks, rand)
+    db_1 = simulate(m, plan, db_1; anticipate=true)
+
+    res = stoch_simulate(m, plan, db_1, shk_sample)
+    for (r, s) in zip(res, shk_sample)
+        tmp = copy(db_1)
+        tmp .= tmp .+ s
+        # it's not anticipated shocks
+        @test !(r ≈ simulate(m, plan, tmp; anticipate=true))
+        # it's not unanticipated shocks
+        @test !(r ≈ simulate(m, plan, tmp; anticipate=false))
+        # it's mixed
+        @test (r ≈ simulate(m, plan, db_1, plan, tmp))
+    end
+
+end


### PR DESCRIPTION
 * Add `stoch_simulate`, which is a version of `simulate` in which we run multiple simulations with the same plan and with the same baseline exogenous data, except that in each simulation we add a different realization of the stochastic shocks. 
 * New data types `SimFailed` and `MaybeSimData = Union{SimData, SimFailed}`.  The return value of `stoch_simulate` is a container of `MaybeSimData`.
 * New function `isfailed`, which tests if a simulation failed or succeeded.
 * Add `copyto!` methods for `Plan`.
