### PR TITLE
Remove itol/imaxiter

### DIFF
--- a/src/stackedtime/simulate.jl
+++ b/src/stackedtime/simulate.jl
@@ -219,14 +219,8 @@ function simulate(m::Model,
                 exog_inds = p_unant[t, Val(:inds)]
                 psim = Plan(m, t:T)
                 psim.exogenous .= p_ant.exogenous[begin+Int(t - t0):end, :]
-                if t == t0
-                    imaxiter = maxiter
-                    itol = tol
-                elseif (maximum(abs, x[t, exog_inds] - exog_unant[t, exog_inds]) < tol) #= && (psim[t0, Val(:inds)] == exog_inds) =#
+                if t !== t0 && (maximum(abs, x[t, exog_inds] - exog_unant[t, exog_inds]) < tol) #= && (psim[t0, Val(:inds)] == exog_inds) =#
                     continue
-                else
-                    imaxiter = 5
-                    itol = sqrt(tol)
                 end
                 setexog!(psim, t0, exog_inds)
                 gdata = StackedTimeSolverData(m, psim, fctype, variant)
@@ -236,11 +230,11 @@ function simulate(m::Model,
                 xx = view(x, sim_range, :)
                 assign_final_condition!(xx, exog_unant[sim_range, :], gdata)
                 if verbose
-                    @info "Simulating $(p_ant.range[t:T]) with $((itol, imaxiter))" # anticipate expectation_horizon gdata.FC
+                    @info "Simulating $(p_ant.range[t:T]) with $((tol, maxiter))" # anticipate expectation_horizon gdata.FC
                 end
-                converged = sim_nr!(xx, gdata, imaxiter, itol, verbose, linesearch)
+                converged = sim_nr!(xx, gdata, maxiter, tol, verbose, linesearch)
                 if warn_maxiter && !converged
-                    @warn("Newton-Raphson reached maximum number of iterations (`imaxiter`).")
+                    @warn("Newton-Raphson reached maximum number of iterations (`maxiter`).")
                 end
                 last_run = Workspace(; t, xx, gdata)
             end


### PR DESCRIPTION
When using the stacked time with unanticipated shocks, the settings `itol` and `imaxiter` are not exposed from the `simulate` command and they are not documented. I am proposing to remove them and let the user decide what should these settings be for all the periods using the normal `tol` and `maxiter` settings.